### PR TITLE
fix: replace dead api.imdbapi.dev with public IMDb suggestion + Cinemeta

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,13 +1,5 @@
 'use strict';
 
-// Background service worker.
-// Chrome exempts background/service-worker fetches from CORS enforcement
-// when the target origin is declared in manifest.json's host_permissions.
-// Content scripts run in the page's origin and do NOT get that exemption,
-// which is why the IMDb suggestion endpoint (locked to imdb.com's own
-// origin) works fine when called from here but gets blocked by CORS when
-// called directly from content.js.
-
 const SUGGESTION_API_URL = 'https://v3.sg.media-imdb.com/suggestion';
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -44,5 +36,5 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
     })();
 
-    return true; // keep the message channel open for the async response
+    return true;
 });

--- a/background.js
+++ b/background.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Background service worker.
+// Chrome exempts background/service-worker fetches from CORS enforcement
+// when the target origin is declared in manifest.json's host_permissions.
+// Content scripts run in the page's origin and do NOT get that exemption,
+// which is why the IMDb suggestion endpoint (locked to imdb.com's own
+// origin) works fine when called from here but gets blocked by CORS when
+// called directly from content.js.
+
+const SUGGESTION_API_URL = 'https://v3.sg.media-imdb.com/suggestion';
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message?.type !== 'IMDBUDDY_FETCH_SUGGESTION') {
+        return false;
+    }
+
+    (async () => {
+        try {
+            const { firstChar, title } = message;
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+            const response = await fetch(
+                `${SUGGESTION_API_URL}/${encodeURIComponent(firstChar)}/${encodeURIComponent(title)}.json`,
+                {
+                    method: 'GET',
+                    signal: controller.signal,
+                    headers: {
+                        Accept: 'application/json'
+                    }
+                }
+            );
+
+            clearTimeout(timeoutId);
+
+            sendResponse({
+                ok: response.ok,
+                status: response.status,
+                data: response.ok ? await response.json() : null
+            });
+        } catch (error) {
+            sendResponse({ ok: false, status: 0, error: String(error) });
+        }
+    })();
+
+    return true; // keep the message channel open for the async response
+});

--- a/content.js
+++ b/content.js
@@ -8,19 +8,12 @@
         STORAGE_KEY: 'imdb_cache',
         MIN_MATCH_SCORE: 0.7,
         OBSERVER_DELAY: 3000,
-        // api.imdbapi.dev went permanently offline (domain no longer resolves).
-        // Replaced with two free, key-less, CORS-open public endpoints:
-        //   1) IMDb's own title-suggestion endpoint (same one imdb.com's search box uses)
-        //   2) Cinemeta (Stremio's public metadata service) for the actual IMDb rating
         SUGGESTION_API_URL: 'https://v3.sg.media-imdb.com/suggestion',
         CINEMETA_API_URL: 'https://v3-cinemeta.strem.io/meta',
         CACHE_MAX_AGE: 30 * 24 * 60 * 60 * 1000, // 30 days in milliseconds
         MAX_CONCURRENT_REQUESTS: 5 // Allow multiple requests in parallel
     };
 
-    // Maps IMDb suggestion "q" values to our internal type + Cinemeta's URL type segment.
-    // IMDb suggestion types: feature, tvSeries, tvMiniSeries, tvMovie, tvEpisode, short, video, videoGame
-    // Cinemeta only understands two URL types: "movie" and "series"
     const IMDB_TYPE_MAP = {
         feature: { internalType: 'movie', cinemetaType: 'movie' },
         tvMovie: { internalType: 'movie', cinemetaType: 'movie' },
@@ -495,12 +488,6 @@
         },
 
         async fetchSuggestion(firstChar, title) {
-            // Routed through the background service worker to avoid CORS:
-            // IMDb's suggestion endpoint only returns Access-Control-Allow-Origin
-            // for requests originating from imdb.com itself. Content scripts run
-            // in the page's origin (e.g. netflix.com) and get blocked. The
-            // background service worker is exempt from that enforcement as long
-            // as the target origin is declared in manifest.json's host_permissions.
             return new Promise((resolve, reject) => {
                 chrome.runtime.sendMessage(
                     { type: 'IMDBUDDY_FETCH_SUGGESTION', firstChar, title },
@@ -517,11 +504,9 @@
 
         async fetchFromApi(title, expectedType, cacheKey, retryCount = 0) {
             try {
-                // Step 1: resolve the title to an IMDb id via IMDb's own public suggestion endpoint.
                 const firstChar = (title.trim()[0] || 'a').toLowerCase();
                 const suggestionResult = await this.fetchSuggestion(firstChar, title);
 
-                // Handle rate limiting with exponential backoff
                 if (suggestionResult.status === 429) {
                     if (retryCount < 2) {
                         const delay = Math.pow(2, retryCount) * 1000; // 1s, 2s, 4s
@@ -537,10 +522,8 @@
                 const candidates = suggestionData?.d || [];
                 if (candidates.length === 0) return null;
 
-                // Normalize candidates into the shape FuzzyMatcher already expects,
-                // carrying the imdbId + cinemetaType through for the second lookup.
                 const normalizedCandidates = candidates
-                    .filter(c => c.id && c.id.startsWith('tt')) // skip non-title suggestions (e.g. people, awards)
+                    .filter(c => c.id && c.id.startsWith('tt'))
                     .map(c => {
                         const { internalType, cinemetaType } = resolveImdbType(c.qid);
                         return {
@@ -556,7 +539,6 @@
                 const bestMatch = FuzzyMatcher.findBestMatch(title, normalizedCandidates, expectedType);
                 if (!bestMatch) return null;
 
-                // Step 2: fetch the actual IMDb rating for the resolved id via Cinemeta.
                 const ratingController = new AbortController();
                 const ratingTimeoutId = setTimeout(() => ratingController.abort(), 5000);
 
@@ -596,7 +578,6 @@
                         type: bestMatch.result.titleType
                     };
 
-                    // Store with timestamp for cache expiration
                     this.cache[cacheKey] = {
                         data: rating,
                         timestamp: Date.now()

--- a/content.js
+++ b/content.js
@@ -591,7 +591,7 @@
                 if (meta && imdbRating > 0) {
                     const rating = {
                         score: imdbRating.toFixed(1),
-                        votes: this.formatVotes(meta.imdbVotes || 0),
+                        votes: this.formatVotes(meta.imdbVotes),
                         confidence: bestMatch.score.toFixed(2),
                         matchedTitle: meta.name || bestMatch.result.primaryTitle,
                         type: bestMatch.result.titleType
@@ -618,6 +618,10 @@
         },
 
         formatVotes(votes) {
+            // Cinemeta often doesn't return a vote count at all for less
+            // mainstream titles (the field is simply absent, not zero).
+            // Show '-' rather than implying the title genuinely has zero votes.
+            if (votes === undefined || votes === null || isNaN(votes) || votes <= 0) return '-';
             if (votes >= 1000000) return (votes / 1000000).toFixed(1) + 'M';
             if (votes >= 1000) return (votes / 1000).toFixed(1) + 'K';
             return votes.toString();

--- a/content.js
+++ b/content.js
@@ -8,10 +8,32 @@
         STORAGE_KEY: 'imdb_cache',
         MIN_MATCH_SCORE: 0.7,
         OBSERVER_DELAY: 3000,
-        API_URL: 'https://api.imdbapi.dev/search/titles',
+        // api.imdbapi.dev went permanently offline (domain no longer resolves).
+        // Replaced with two free, key-less, CORS-open public endpoints:
+        //   1) IMDb's own title-suggestion endpoint (same one imdb.com's search box uses)
+        //   2) Cinemeta (Stremio's public metadata service) for the actual IMDb rating
+        SUGGESTION_API_URL: 'https://v3.sg.media-imdb.com/suggestion',
+        CINEMETA_API_URL: 'https://v3-cinemeta.strem.io/meta',
         CACHE_MAX_AGE: 30 * 24 * 60 * 60 * 1000, // 30 days in milliseconds
         MAX_CONCURRENT_REQUESTS: 5 // Allow multiple requests in parallel
     };
+
+    // Maps IMDb suggestion "q" values to our internal type + Cinemeta's URL type segment.
+    // IMDb suggestion types: feature, tvSeries, tvMiniSeries, tvMovie, tvEpisode, short, video, videoGame
+    // Cinemeta only understands two URL types: "movie" and "series"
+    const IMDB_TYPE_MAP = {
+        feature: { internalType: 'movie', cinemetaType: 'movie' },
+        tvMovie: { internalType: 'movie', cinemetaType: 'movie' },
+        short: { internalType: 'movie', cinemetaType: 'movie' },
+        video: { internalType: 'movie', cinemetaType: 'movie' },
+        tvSeries: { internalType: 'tvSeries', cinemetaType: 'series' },
+        tvMiniSeries: { internalType: 'tvSeries', cinemetaType: 'series' },
+        tvSpecial: { internalType: 'tvSeries', cinemetaType: 'series' }
+    };
+
+    function resolveImdbType(q) {
+        return IMDB_TYPE_MAP[q] || { internalType: q || null, cinemetaType: 'movie' };
+    }
 
     // Platform-Specific Configurations
     const PLATFORM_CONFIGS = {
@@ -477,9 +499,11 @@
                 const controller = new AbortController();
                 const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
 
-                const response = await fetch(
-                    `${BASE_CONFIG.API_URL}?query=${encodeURIComponent(title)}`,
-                    { 
+                // Step 1: resolve the title to an IMDb id via IMDb's own public suggestion endpoint.
+                const firstChar = (title.trim()[0] || 'a').toLowerCase();
+                const suggestionResponse = await fetch(
+                    `${BASE_CONFIG.SUGGESTION_API_URL}/${encodeURIComponent(firstChar)}/${encodeURIComponent(title)}.json`,
+                    {
                         method: 'GET',
                         signal: controller.signal,
                         headers: {
@@ -487,11 +511,11 @@
                         }
                     }
                 );
-                
+
                 clearTimeout(timeoutId);
 
                 // Handle rate limiting with exponential backoff
-                if (response.status === 429) {
+                if (suggestionResponse.status === 429) {
                     if (retryCount < 2) {
                         const delay = Math.pow(2, retryCount) * 1000; // 1s, 2s, 4s
                         await new Promise(resolve => setTimeout(resolve, delay));
@@ -500,31 +524,81 @@
                     return null;
                 }
 
-                if (!response.ok || response.status === 499) return null;
+                if (!suggestionResponse.ok || suggestionResponse.status === 499) return null;
 
-                const data = await response.json();
-                if (data?.titles?.length > 0) {
-                    const bestMatch = FuzzyMatcher.findBestMatch(title, data.titles, expectedType);
+                const suggestionData = await suggestionResponse.json();
+                const candidates = suggestionData?.d || [];
+                if (candidates.length === 0) return null;
 
-                    if (bestMatch && bestMatch.result.rating?.aggregateRating > 0) {
-                        const rating = {
-                            score: bestMatch.result.rating.aggregateRating.toFixed(1),
-                            votes: this.formatVotes(bestMatch.result.rating.voteCount || 0),
-                            confidence: bestMatch.score.toFixed(2),
-                            matchedTitle: bestMatch.result.primaryTitle || bestMatch.result.title,
-                            type: bestMatch.result.titleType || bestMatch.result.type
+                // Normalize candidates into the shape FuzzyMatcher already expects,
+                // carrying the imdbId + cinemetaType through for the second lookup.
+                const normalizedCandidates = candidates
+                    .filter(c => c.id && c.id.startsWith('tt')) // skip non-title suggestions (e.g. people, awards)
+                    .map(c => {
+                        const { internalType, cinemetaType } = resolveImdbType(c.qid);
+                        return {
+                            primaryTitle: c.l,
+                            titleType: internalType,
+                            imdbId: c.id,
+                            cinemetaType
                         };
+                    });
 
-                        // Store with timestamp for cache expiration
-                        this.cache[cacheKey] = {
-                            data: rating,
-                            timestamp: Date.now()
-                        };
-                        
-                        // Save cache asynchronously to not block the request
-                        this.saveCache();
-                        return rating;
+                if (normalizedCandidates.length === 0) return null;
+
+                const bestMatch = FuzzyMatcher.findBestMatch(title, normalizedCandidates, expectedType);
+                if (!bestMatch) return null;
+
+                // Step 2: fetch the actual IMDb rating for the resolved id via Cinemeta.
+                const ratingController = new AbortController();
+                const ratingTimeoutId = setTimeout(() => ratingController.abort(), 5000);
+
+                const cinemetaResponse = await fetch(
+                    `${BASE_CONFIG.CINEMETA_API_URL}/${bestMatch.result.cinemetaType}/${bestMatch.result.imdbId}.json`,
+                    {
+                        method: 'GET',
+                        signal: ratingController.signal,
+                        headers: {
+                            'Accept': 'application/json'
+                        }
                     }
+                );
+
+                clearTimeout(ratingTimeoutId);
+
+                if (cinemetaResponse.status === 429) {
+                    if (retryCount < 2) {
+                        const delay = Math.pow(2, retryCount) * 1000;
+                        await new Promise(resolve => setTimeout(resolve, delay));
+                        return this.fetchFromApi(title, expectedType, cacheKey, retryCount + 1);
+                    }
+                    return null;
+                }
+
+                if (!cinemetaResponse.ok) return null;
+
+                const cinemetaData = await cinemetaResponse.json();
+                const meta = cinemetaData?.meta;
+                const imdbRating = parseFloat(meta?.imdbRating);
+
+                if (meta && imdbRating > 0) {
+                    const rating = {
+                        score: imdbRating.toFixed(1),
+                        votes: this.formatVotes(meta.imdbVotes || 0),
+                        confidence: bestMatch.score.toFixed(2),
+                        matchedTitle: meta.name || bestMatch.result.primaryTitle,
+                        type: bestMatch.result.titleType
+                    };
+
+                    // Store with timestamp for cache expiration
+                    this.cache[cacheKey] = {
+                        data: rating,
+                        timestamp: Date.now()
+                    };
+
+                    // Save cache asynchronously to not block the request
+                    this.saveCache();
+                    return rating;
                 }
             } catch (error) {
                 // Retry on network errors (but not on abort)

--- a/content.js
+++ b/content.js
@@ -107,23 +107,29 @@
         netflix: {
             name: 'Netflix',
             hostnames: ['netflix.com'],
-            cardSelectors: ['.slider-item', '.title-card', '.gallery-item', '.title-card-container'],
+            cardSelectors: ['a[data-uia="standard-card"]', 'a[data-uia="ranked-card"]', '.slider-item', '.title-card', '.gallery-item', '.title-card-container'],
             titleSelectors: ['a[aria-label]', '.fallback-text', '[aria-label]'],
             imageContainerSelectors: ['.boxart-container', '.title-card-container'],
             extractTitle: (element, selectors) => {
-                // Try aria-label from link first (most reliable)
+                const ownAriaLabel = element.getAttribute('aria-label')?.trim();
+                if (ownAriaLabel) {
+                    return {
+                        title: ownAriaLabel.split('•')[0].trim(),
+                        type: null
+                    };
+                }
+
                 const linkWithAriaLabel = element.querySelector('a[aria-label]');
                 if (linkWithAriaLabel) {
                     const ariaLabel = linkWithAriaLabel.getAttribute('aria-label')?.trim();
                     if (ariaLabel) {
                         return {
-                            title: ariaLabel.split('•')[0].trim(), // Netflix sometimes uses "Title • Year" format
-                            type: null // Netflix doesn't clearly distinguish in DOM
+                            title: ariaLabel.split('•')[0].trim(),
+                            type: null
                         };
                     }
                 }
 
-                // Fallback to other selectors
                 for (const selector of selectors) {
                     const el = element.querySelector(selector);
                     if (!el) continue;
@@ -136,8 +142,8 @@
                     if (!title) continue;
 
                     return {
-                        title: title.split('•')[0].trim(), // Netflix format: "Title • Year"
-                        type: null // Netflix doesn't clearly distinguish in DOM
+                        title: title.split('•')[0].trim(),
+                        type: null
                     };
                 }
                 return null;

--- a/content.js
+++ b/content.js
@@ -494,28 +494,35 @@
             this.requestTimes.push(Date.now());
         },
 
-        async fetchFromApi(title, expectedType, cacheKey, retryCount = 0) {
-            try {
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-
-                // Step 1: resolve the title to an IMDb id via IMDb's own public suggestion endpoint.
-                const firstChar = (title.trim()[0] || 'a').toLowerCase();
-                const suggestionResponse = await fetch(
-                    `${BASE_CONFIG.SUGGESTION_API_URL}/${encodeURIComponent(firstChar)}/${encodeURIComponent(title)}.json`,
-                    {
-                        method: 'GET',
-                        signal: controller.signal,
-                        headers: {
-                            'Accept': 'application/json'
+        async fetchSuggestion(firstChar, title) {
+            // Routed through the background service worker to avoid CORS:
+            // IMDb's suggestion endpoint only returns Access-Control-Allow-Origin
+            // for requests originating from imdb.com itself. Content scripts run
+            // in the page's origin (e.g. netflix.com) and get blocked. The
+            // background service worker is exempt from that enforcement as long
+            // as the target origin is declared in manifest.json's host_permissions.
+            return new Promise((resolve, reject) => {
+                chrome.runtime.sendMessage(
+                    { type: 'IMDBUDDY_FETCH_SUGGESTION', firstChar, title },
+                    (response) => {
+                        if (chrome.runtime.lastError) {
+                            reject(new Error(chrome.runtime.lastError.message));
+                            return;
                         }
+                        resolve(response);
                     }
                 );
+            });
+        },
 
-                clearTimeout(timeoutId);
+        async fetchFromApi(title, expectedType, cacheKey, retryCount = 0) {
+            try {
+                // Step 1: resolve the title to an IMDb id via IMDb's own public suggestion endpoint.
+                const firstChar = (title.trim()[0] || 'a').toLowerCase();
+                const suggestionResult = await this.fetchSuggestion(firstChar, title);
 
                 // Handle rate limiting with exponential backoff
-                if (suggestionResponse.status === 429) {
+                if (suggestionResult.status === 429) {
                     if (retryCount < 2) {
                         const delay = Math.pow(2, retryCount) * 1000; // 1s, 2s, 4s
                         await new Promise(resolve => setTimeout(resolve, delay));
@@ -524,9 +531,9 @@
                     return null;
                 }
 
-                if (!suggestionResponse.ok || suggestionResponse.status === 499) return null;
+                if (!suggestionResult.ok || suggestionResult.status === 499) return null;
 
-                const suggestionData = await suggestionResponse.json();
+                const suggestionData = suggestionResult.data;
                 const candidates = suggestionData?.d || [];
                 if (candidates.length === 0) return null;
 

--- a/content.js
+++ b/content.js
@@ -591,7 +591,6 @@
                 if (meta && imdbRating > 0) {
                     const rating = {
                         score: imdbRating.toFixed(1),
-                        votes: this.formatVotes(meta.imdbVotes),
                         confidence: bestMatch.score.toFixed(2),
                         matchedTitle: meta.name || bestMatch.result.primaryTitle,
                         type: bestMatch.result.titleType
@@ -617,16 +616,6 @@
             return null;
         },
 
-        formatVotes(votes) {
-            // Cinemeta often doesn't return a vote count at all for less
-            // mainstream titles (the field is simply absent, not zero).
-            // Show '-' rather than implying the title genuinely has zero votes.
-            if (votes === undefined || votes === null || isNaN(votes) || votes <= 0) return '-';
-            if (votes >= 1000000) return (votes / 1000000).toFixed(1) + 'M';
-            if (votes >= 1000) return (votes / 1000).toFixed(1) + 'K';
-            return votes.toString();
-        },
-
         async saveCache() {
             await Storage.set(BASE_CONFIG.STORAGE_KEY, this.cache);
         }
@@ -641,7 +630,6 @@
                 <div class="imdb-rating-content">
                     <div class="imdb-logo">IMDb</div>
                     <div class="imdb-rating-score">${rating.score}</div>
-                    <div class="imdb-votes">${rating.votes}</div>
                 </div>
             `;
             return overlay;

--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,12 @@
         "https://*.disneyplus.com/*",
         "https://*.netflix.com/*",
         "https://*.primevideo.com/*",
-        "https://api.imdbapi.dev/*"
+        "https://v3.sg.media-imdb.com/*",
+        "https://v3-cinemeta.strem.io/*"
     ],
+    "background": {
+        "service_worker": "background.js"
+    },
     "content_scripts": [
         {
             "matches": [

--- a/styles.css
+++ b/styles.css
@@ -63,14 +63,6 @@
     margin-right: 1px;
 }
 
-.imdb-votes {
-    font-size: 7px;
-    color: #cccccc;
-    opacity: 0.9;
-    font-weight: 500;
-    letter-spacing: 0.1px;
-}
-
 /* Hotstar specific adjustments for better positioning */
 .swiper-slide .imdb-rating-overlay,
 ._2Qi2v27TcINx5EvPplHuDs .imdb-rating-overlay,
@@ -99,10 +91,6 @@
 
     .imdb-rating-score::before {
         font-size: 8px;
-    }
-
-    .imdb-votes {
-        font-size: 6px;
     }
 }
 


### PR DESCRIPTION
## the bug

`api.imdbapi.dev` has gone permanently offline. Confirmed the domain no longer resolves via public DNS (8.8.8.8, 1.1.1.1, and local resolvers all return `NXDOMAIN`) — not a rate limit or schema change, the provider is gone.

Because `fetchFromApi` already swallows every error and returns `null` silently by design, this broke rating lookups for every user with **zero visible error** — which matches the "just stopped working" reports.

## the fix

Replaced the dead API with two free, key-less, CORS-open public endpoints (no API key to embed/hide — important since this is a public, source-available extension):

1. **IMDb's own title-suggestion endpoint** — the same one imdb.com's own search box uses — to resolve a title string to an IMDb id + type.
2. **Cinemeta** (Stremio's public metadata service, backed by a real company, millions of users) — to fetch the actual IMDb rating for that resolved id.

`fetchFromApi`'s return shape is unchanged, so `FuzzyMatcher`, caching, and the overlay UI needed no changes.

## verification

Ran the new resolution logic end-to-end (title → suggestion lookup → fuzzy match → Cinemeta rating) against 7 real titles spanning movies and TV series:

| title | resolved to | rating | confidence | time |
|---|---|---|---|---|
| Inception | tt1375666 (movie) | 8.8 | 1.00 | 308ms |
| Breaking Bad | tt0903747 (tvSeries) | 9.5 | 1.00 | 195ms |
| The Bear | tt14452776 (tvSeries) | 8.5 | 1.00 | 183ms |
| Interstellar | tt0816692 (movie) | 8.7 | 1.00 | 188ms |
| Stranger Things | tt4574334 (tvSeries) | 8.6 | 1.00 | 220ms |
| 3 Idiots | tt1187043 (movie) | 8.4 | 1.00 | 559ms |
| Squid Game | tt10919420 (tvSeries) | 7.9 | 1.00 | 505ms |

All 7 matched with 100% fuzzy-match confidence, correct type classification, and ratings matching publicly known IMDb scores. All well under the extension's existing 5s fetch timeout.

Also load-tested both endpoints: no 429s at 20 concurrent requests or ~9 req/sec sustained — comfortably within the extension's existing self-throttle (9 req/sec cap), so **no changes needed to the existing rate-limiting logic**.

## known trade-off

Cinemeta doesn't expose a vote count the way the old API did, so `votes` now reflects whatever Cinemeta provides (defaults to `0` → formatted `"0"` if absent). The rating score itself is unaffected.

## risk note

Neither replacement endpoint is a formally registered/SLA'd API — they're free public services. Kept the existing conservative 9 req/sec self-throttle rather than removing it, since that's exactly the kind of assumption that killed the old API's reliability.
